### PR TITLE
Fix the description for 'observable.map(f)'

### DIFF
--- a/api.html
+++ b/api.html
@@ -350,7 +350,7 @@ be called when the stream ends. Just like <code>subscribe</code>, this method re
 
 <p><a name="observable-map"></a>
 <a href="#observable-map" title="observable.map(@ : Observable[A], f : A -&gt; B) : Observable[B]"><code>observable.map(f)</code></a> maps values using given function, returning a new
-EventStream. Instead of a function, you can also provide a constant
+stream/property. Instead of a function, you can also provide a constant
 value. Further, you can use a property extractor string like
 &quot;.keyCode&quot;. So, if f is a string starting with a
 dot, the elements will be mapped to the corresponding field/function in the event


### PR DESCRIPTION
The current documentation for `observable.map` states that this function returns a new EventStream, which is not accurate. That lead me to believe that if used in a property the result would be an 'EventStream' rather than a property, which I thought was odd. However, after I tested it I realized that it returns a property when it's used with a property and  stream when it's used with  stream, which is what I would expect.