### PR TITLE
Use HTTPS to query themoviedb.org

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -65,7 +65,7 @@ Type a word with at least three characters into the box.
 <script>
     function queryMovie(query) {
       return jQuery.get(
-          'http://api.themoviedb.org/3/search/movie?api_key=9eae05e667b4d5d9fbb75d27622347fe&query=' + query
+          'https://api.themoviedb.org/3/search/movie?api_key=9eae05e667b4d5d9fbb75d27622347fe&query=' + query
       ).then(function(r) { return r.results; });
     }
 


### PR DESCRIPTION
Any recent version of Chrome will block XHR requests from https-sites to http-sites:

    Mixed Content: The page at 'https://baconjs.github.io/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://api.themoviedb.org/3/search/movie?api_key=[---]&query=[---]'. This request has been blocked; the content must be served over HTTPS.