### PR TITLE
Make code blocks selectable

### DIFF
--- a/bacon.css
+++ b/bacon.css
@@ -1,6 +1,3 @@
-div:empty {
-  display: none;
-}
 body {
     margin-bottom: 5em;
     color: rgb(50, 52, 50);


### PR DESCRIPTION
Currently text selection doesn't work on code blocks, which makes it really hard to copy-paste code examples. Bug is caused by CSS rule that hides all `div:empty`.

Tested on Chrome, Safari and Firefox.