### PR TITLE
Remove extra .not() from first tutorial

### DIFF
--- a/content/tutorials/1_Registration_Form.md
+++ b/content/tutorials/1_Registration_Form.md
@@ -240,7 +240,7 @@ current property value.
 You could also do the same by
 
 ```javascript
-buttonEnabled.not().assign(setEnabled, registerButton)
+buttonEnabled.assign(setEnabled, registerButton)
 ```
 
 Now we rely on the `setEnabled` function that's defined in our source code, as well as `registerButton`. The above


### PR DESCRIPTION
With the `.not()` in place, the button gets disabled when both text fields contain text. I believe the intended behaviour was to *enable* the button when both fields contain text.