### PR TITLE
Load v1 on v1 API page

### DIFF
--- a/api.html
+++ b/api.html
@@ -17,7 +17,7 @@
 <link href='//fonts.googleapis.com/css?family=Yanone+Kaffeesatz' rel='stylesheet' type='text/css'>
 
 <script src="//codeorigin.jquery.com/jquery-2.1.1.min.js"></script>
-<script src="//cdnjs.cloudflare.com/ajax/libs/bacon.js/2.0.7/Bacon.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/bacon.js/1.0.1/Bacon.min.js"></script>
 
 
 <script src="codemirror/codemirror.js"></script>


### PR DESCRIPTION
I often visit the website not only to read the API docs, but also to experiment with Bacon in the console. It would be nice for the version of Bacon to be loaded on each API docs page to match the version of Bacon in the API docs. This change aligns versions on the API 1.0 page.